### PR TITLE
fix(eye): honest classifier/memory status + large-file & NATS auth (May bug batch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,11 @@ jobs:
         # matches the in-repo golden vectors — see the header in
         # tests/sga_consistency.mjs for the exact contract. This genuinely
         # gates: JS classifier drift or a parse/runtime regression fails CI.
+
+      - name: Bug-batch regression check
+        run: node tests/bug_batch.mjs
+        # Regression coverage for the May bug batch (#21, #22, #24, #26) plus a
+        # guard for #27: constellation classifier honesty, SVG memory-node
+        # gating, the large-file #canvasInfo status target, tempo_bpm:0
+        # preservation, and NATS user:pass URL parsing. Spawns the server with
+        # an unusable native classifier and a stub radio — see the file header.

--- a/attention-bridge.js
+++ b/attention-bridge.js
@@ -32,13 +32,26 @@ const SUBJECT = "KANNAKA.attention.eye";
 const SOURCE_NAME = `kannaka-eye:${HEMISPHERE}`;
 
 function parseNatsUrl(u) {
-  // nats://[token@]host[:port]
+  // nats://[user:pass@ | token@]host[:port]
+  // A credential containing ':' is username/password (NATS authz — the
+  // kannaka_internal account uses this); a bare credential is a token.
+  // Pre-fix the whole credential was returned as `token`, so a standard
+  // `nats://user:pass@host` URL was sent as auth_token and never authed. (#22)
   const m = u.match(/^nats:\/\/(?:([^@]+)@)?([^:/]+)(?::(\d+))?/i);
-  if (!m) return { host: "localhost", port: 4222, token: null };
+  if (!m) return { host: "localhost", port: 4222, user: null, pass: null, token: null };
+  const cred = m[1] || null;
+  let user = null, pass = null, token = null;
+  if (cred != null) {
+    const ci = cred.indexOf(":");
+    if (ci >= 0) { user = cred.slice(0, ci); pass = cred.slice(ci + 1); }
+    else { token = cred; }
+  }
   return {
     host: m[2] || "localhost",
     port: m[3] ? parseInt(m[3], 10) : 4222,
-    token: m[1] || null,
+    user,
+    pass,
+    token,
   };
 }
 
@@ -53,8 +66,18 @@ class AttentionBridge {
   }
 
   connect() {
-    const { host, port, token } = parseNatsUrl(NATS_URL);
-    const authToken = NATS_TOKEN || token;
+    const parsed = parseNatsUrl(NATS_URL);
+    const { host, port } = parsed;
+    // Auth precedence (#22): explicit env vars win, then credentials embedded
+    // in NATS_URL. user/pass (if present) takes precedence over a token so a
+    // `nats://user:pass@host` URL authenticates instead of being sent as a
+    // bare token.
+    let user = null, pass = null, authToken = null;
+    if (NATS_USER) { user = NATS_USER; pass = NATS_PASSWORD || ""; }
+    else if (parsed.user) { user = parsed.user; pass = parsed.pass || ""; }
+    if (NATS_TOKEN) authToken = NATS_TOKEN;
+    else if (!user && parsed.token) authToken = parsed.token;
+    const authMode = user ? "user" : authToken ? "token" : "none";
     const sock = net.createConnection({ host, port }, () => {
       // Wait for INFO before sending CONNECT (per NATS protocol).
     });
@@ -67,15 +90,17 @@ class AttentionBridge {
         if (line.startsWith("INFO ")) {
           // Send CONNECT — minimal, no subscriptions needed (publish-only).
           const connect = { verbose: false, pedantic: false, lang: "node-raw", name: SOURCE_NAME, protocol: 1 };
-          if (authToken) connect.auth_token = authToken;
-          if (NATS_USER) { connect.user = NATS_USER; connect.pass = NATS_PASSWORD || ""; }
+          // user/pass and token are mutually exclusive auth modes; prefer
+          // user/pass when we have it.
+          if (user) { connect.user = user; connect.pass = pass; }
+          else if (authToken) connect.auth_token = authToken;
           sock.write(`CONNECT ${JSON.stringify(connect)}\r\n`);
           // Send PING to test the connection.
           sock.write("PING\r\n");
         } else if (line === "PONG") {
           if (!this._connected) {
             this._connected = true;
-            console.log(`[attention-bridge] connected to ${host}:${port} (hemisphere=${HEMISPHERE})`);
+            console.log(`[attention-bridge] connected to ${host}:${port} (hemisphere=${HEMISPHERE}, auth=${authMode})`);
           }
         } else if (line === "PING") {
           sock.write("PONG\r\n");
@@ -160,4 +185,4 @@ class AttentionBridge {
   }
 }
 
-module.exports = { AttentionBridge, HEMISPHERE, SUBJECT };
+module.exports = { AttentionBridge, HEMISPHERE, SUBJECT, parseNatsUrl };

--- a/server.js
+++ b/server.js
@@ -195,6 +195,34 @@ function classifyNative(inputBuffer) {
 }
 
 /**
+ * Probe whether the native classifier is actually usable (#21).
+ *
+ * KANNAKA_BIN existing on disk does NOT mean Eye can classify natively: the
+ * current kannaka CLI has no `classify` subcommand, so classifyNative() fails
+ * on every request and silently falls back to the JS classifier. Reporting
+ * "native" from mere file presence made /api/constellation and the SVG lie
+ * about whether memory-native classification is wired up.
+ *
+ * Probe once with a tiny sample, memoize the result, and only let callers
+ * claim "native" when the binary genuinely returns a classified glyph. If a
+ * future kannaka ships a real classify subcommand this begins reporting native
+ * truthfully with no further changes. Resolved once at first use, like
+ * KANNAKA_BIN itself — a rebuild mid-run needs a restart to be picked up.
+ */
+let _nativeProbe = null; // memoized Promise<boolean>
+function nativeClassifierAvailable() {
+  if (_nativeProbe) return _nativeProbe;
+  if (!KANNAKA_BIN) {
+    _nativeProbe = Promise.resolve(false);
+    return _nativeProbe;
+  }
+  _nativeProbe = classifyNative(Buffer.from([0, 128, 255]))
+    .then((r) => !!(r && Array.isArray(r.fold_sequence) && r.fold_sequence.length > 0))
+    .catch(() => false);
+  return _nativeProbe;
+}
+
+/**
  * Publish a GlyphPublished event to Flux (ADR-0015 schema).
  * Fire-and-forget with throttle (max 1/sec).
  */
@@ -1690,13 +1718,17 @@ function handleFile(file) {
     let chunksRead = 0;
     let chunkIndex = 0;
     
-    document.getElementById('info-text').textContent = 
+    // Progress goes to the existing #canvasInfo status line. The page never
+    // rendered an #info-text element, so the previous getElementById('info-text')
+    // dereferenced null and threw before sampling could start on any >1 MB
+    // upload. (#26)
+    document.getElementById('canvasInfo').textContent =
       'Reading ' + (file.size / (1024*1024)).toFixed(1) + ' MB...';
-    
+
     function readNextChunk() {
       if (chunkIndex >= totalChunks || samples.length >= MAX_SAMPLES) {
-        document.getElementById('info-text').textContent = 
-          'Sampled ' + samples.length.toLocaleString() + ' points from ' + 
+        document.getElementById('canvasInfo').textContent =
+          'Sampled ' + samples.length.toLocaleString() + ' points from ' +
           (file.size / (1024*1024)).toFixed(1) + ' MB';
         processInput(samples, 'bytes');
         return;
@@ -2126,7 +2158,7 @@ const server = http.createServer((req, res) => {
       r.on("timeout", () => { r.destroy(); resolve(null); });
     });
 
-    radioCheck.then((radioState) => {
+    Promise.all([radioCheck, nativeClassifierAvailable()]).then(([radioState, nativeOk]) => {
       // Fano plane vertices (7 points) in a circle
       const cx = 200, cy = 200, radius = 150;
       const pts = [];
@@ -2148,11 +2180,15 @@ const server = http.createServer((req, res) => {
         dream: "#ec4899"
       };
 
-      // Build active glyph dots (eye is always active, radio if running)
+      // Build active glyph dots. Eye is always active; radio lights only when
+      // /api/state returns 2xx; memory lights only when the native classifier
+      // probe actually succeeds — previously Memory was hardcoded active with
+      // no check at all, so the SVG implied kannaka-memory was wired up even
+      // when Eye had verified nothing. (#24, #21)
       const dots = [];
       dots.push({ idx: 0, source: "eye", label: "Eye" });
       if (radioState) dots.push({ idx: 3, source: "radio", label: "Radio" });
-      dots.push({ idx: 6, source: "memory", label: "Memory" });
+      if (nativeOk) dots.push({ idx: 6, source: "memory", label: "Memory" });
 
       let svg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
@@ -2189,7 +2225,8 @@ const server = http.createServer((req, res) => {
 
       // Status text
       svg += `  <text x="200" y="380" text-anchor="middle" fill="#555" font-family="monospace" font-size="10">`;
-      svg += `eye:ON radio:${radioState ? "ON" : "OFF"} memory:${KANNAKA_BIN ? "BIN" : "JS"}`;
+      const memoryStatus = nativeOk ? "NATIVE" : (KANNAKA_BIN ? "UNVERIFIED" : "OFF");
+      svg += `eye:ON radio:${radioState ? "ON" : "OFF"} memory:${memoryStatus}`;
       svg += `</text>\n`;
       svg += `</svg>`;
 
@@ -2295,7 +2332,7 @@ function refresh() {
         document.getElementById("dot-memory").className = "dot off";
         document.getElementById("card-memory").className = "card offline";
         document.getElementById("meta-memory").innerHTML =
-          "Status: <span>no binary</span><br>" +
+          "Status: <span>native unavailable</span><br>" +
           "Classifier: <span>JS fallback</span>";
       }
     })
@@ -2315,7 +2352,10 @@ setInterval(refresh, 10000);
 
   // API: Constellation status
   if (parsed.pathname === "/api/constellation" && req.method === "GET") {
-    const checks = { eye: true, classifier: KANNAKA_BIN ? "native" : "fallback" };
+    // classifier is reported from an actual native-classifier probe, not from
+    // KANNAKA_BIN file presence — otherwise Eye claimed "native" while every
+    // request silently used the JS fallback. (#21)
+    const checks = { eye: true };
 
     // Check radio (#18 — route through radioRequest so remote / TLS-fronted
     // origins also work; #17-family — bail on non-2xx so error envelopes
@@ -2334,7 +2374,8 @@ setInterval(refresh, 10000);
       r.on("timeout", () => { r.destroy(); resolve(null); });
     });
 
-    radioCheck.then((radioState) => {
+    Promise.all([radioCheck, nativeClassifierAvailable()]).then(([radioState, nativeOk]) => {
+      checks.classifier = nativeOk ? "native" : "fallback";
       // Prefer `current.title` (canonical now-playing) over a
       // playlist[currentTrackIdx] lookup which is null when /api/state
       // omits the playlist array. (#12)

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for the May bug batch (issues #21, #22, #24, #26) plus a
+ * guard for the already-fixed #27. Hermetic: spawns the real server on a free
+ * port with the native classifier forced to an unusable path, and drives the
+ * affected endpoints. No external deps, no network beyond localhost.
+ *
+ *   #21  /api/constellation reports classifier from an ACTUAL native probe,
+ *        not from KANNAKA_BIN file presence. With a binary path that can't
+ *        classify, it must report "fallback" (pre-fix: lied "native").
+ *   #24  /api/constellation.svg must NOT light the Memory node unless the
+ *        native classifier is verified (pre-fix: Memory hardcoded active).
+ *   #26  the served page must route large-file progress to #canvasInfo, not a
+ *        nonexistent #info-text node (pre-fix: null deref on >1 MB uploads).
+ *   #27  /api/radio must preserve an explicit tempo_bpm: 0 as a feature byte
+ *        (pre-fix: 0 was treated as falsy/absent and dropped).
+ *   #22  attention-bridge parses nats://user:pass@host into user/pass, and a
+ *        bare nats://token@host into a token (pre-fix: user:pass sent as one
+ *        auth_token).
+ *
+ * Usage: node tests/bug_batch.mjs   (exit 0 iff all pass)
+ */
+
+import { spawn } from "child_process";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import net from "net";
+import http from "http";
+
+import { parseNatsUrl } from "../attention-bridge.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EYE_DIR = join(__dirname, "..");
+
+// A path that cannot exist: server.js short-circuits KANNAKA_BIN auto-detect
+// on this truthy value, then execFile fails with ENOENT so the native probe
+// resolves false. This makes "binary configured but unusable" deterministic
+// on every host — the exact condition #21 is about.
+const FAKE_BIN = join(__dirname, "__no_native_classifier__", "kannaka");
+
+let passed = 0;
+let failed = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS  ${name}`);
+    passed++;
+  } else {
+    console.log(`FAIL  ${name}${detail ? " — " + detail : ""}`);
+    failed++;
+  }
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function request(port, path, method = "GET") {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: "127.0.0.1", port, path, method, timeout: 10000 },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => resolve({ status: res.statusCode, body: data }));
+      }
+    );
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("request timed out")); });
+    req.end();
+  });
+}
+
+async function waitReady(port, timeoutMs = 20000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr = "unknown";
+  while (Date.now() < deadline) {
+    try {
+      const res = await request(port, "/api/attention/stats", "GET");
+      if (res.status === 200) return;
+      lastErr = `status ${res.status}`;
+    } catch (e) {
+      lastErr = e.message;
+    }
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  throw new Error(`server did not become ready in ${timeoutMs}ms (last: ${lastErr})`);
+}
+
+// Minimal stub of kannaka-radio: answers /api/perception with an explicit
+// tempo_bpm of 0 (the #27 edge case) and no other perception fields beyond
+// valence/energy.
+function startStubRadio() {
+  return new Promise((resolve) => {
+    const srv = http.createServer((req, res) => {
+      if (req.url === "/api/perception") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ tempo_bpm: 0, valence: 0.5, rms_energy: 0.25 }));
+      } else {
+        res.writeHead(404);
+        res.end("{}");
+      }
+    });
+    srv.listen(0, "127.0.0.1", () => resolve({ srv, port: srv.address().port }));
+  });
+}
+
+async function main() {
+  // ── #22: pure parser unit tests (no server needed) ──
+  {
+    const up = parseNatsUrl("nats://alice:secret@127.0.0.1:45229");
+    check("#22 user:pass URL → user field", up.user === "alice", `got user=${JSON.stringify(up.user)}`);
+    check("#22 user:pass URL → pass field", up.pass === "secret", `got pass=${JSON.stringify(up.pass)}`);
+    check("#22 user:pass URL → no token", up.token === null, `got token=${JSON.stringify(up.token)}`);
+    check("#22 user:pass URL → host/port", up.host === "127.0.0.1" && up.port === 45229, `got ${up.host}:${up.port}`);
+
+    const tk = parseNatsUrl("nats://sometoken@host:4222");
+    check("#22 token URL → token field", tk.token === "sometoken", `got token=${JSON.stringify(tk.token)}`);
+    check("#22 token URL → no user/pass", tk.user === null && tk.pass === null, `got user=${tk.user} pass=${tk.pass}`);
+
+    const plain = parseNatsUrl("nats://localhost:4222");
+    check("#22 plain URL → no creds", plain.user === null && plain.token === null, `got user=${plain.user} token=${plain.token}`);
+  }
+
+  const stub = await startStubRadio();
+  const port = await getFreePort();
+  const child = spawn(process.execPath, ["server.js", "--port", String(port)], {
+    cwd: EYE_DIR,
+    env: {
+      ...process.env,
+      KANNAKA_BIN: FAKE_BIN,           // native classifier configured but unusable
+      EYE_PORT: "",
+      NATS_URL: "nats://127.0.0.1:1",  // dead NATS; bridge stays silent
+      RADIO_URL: `http://127.0.0.1:${stub.port}`,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let serverLog = "";
+  child.stdout.on("data", (d) => (serverLog += d));
+  child.stderr.on("data", (d) => (serverLog += d));
+
+  try {
+    await waitReady(port);
+
+    // ── #21: constellation classifier is honest ──
+    {
+      const res = await request(port, "/api/constellation", "GET");
+      const body = JSON.parse(res.body);
+      check("#21 /api/constellation classifier is 'fallback' when native unusable",
+        body.classifier === "fallback", `got ${JSON.stringify(body.classifier)}`);
+    }
+
+    // ── #24: SVG does not light Memory without a verified probe ──
+    {
+      const res = await request(port, "/api/constellation.svg", "GET");
+      const svg = res.body;
+      check("#24 SVG omits Memory node label when native unverified",
+        !svg.includes(">Memory<"), "SVG still contains a Memory label");
+      check("#24 SVG status text marks memory UNVERIFIED (binary set, probe failed)",
+        svg.includes("memory:UNVERIFIED"), `status text: ${(svg.match(/eye:ON[^<]*/) || [""])[0]}`);
+    }
+
+    // ── #26: large-file progress targets #canvasInfo, not #info-text ──
+    {
+      const res = await request(port, "/", "GET");
+      const html = res.body;
+      check("#26 page routes large-file progress to #canvasInfo",
+        html.includes("getElementById('canvasInfo').textContent"),
+        "no canvasInfo progress write found");
+      check("#26 page has no active #info-text null-deref call",
+        !html.includes("getElementById('info-text').textContent"),
+        "page still writes to a nonexistent #info-text element");
+    }
+
+    // ── #27: explicit tempo_bpm: 0 is preserved ──
+    {
+      const res = await request(port, "/api/radio", "GET");
+      const body = JSON.parse(res.body);
+      // features = [tempo(0), valence, rms] — tempo must be present.
+      check("#27 /api/radio preserves tempo_bpm:0 (featureCount includes tempo)",
+        body.featureCount === 3, `got featureCount=${body.featureCount}, features=${JSON.stringify(body.features)}`);
+      check("#27 /api/radio emits the 0 tempo byte first",
+        Array.isArray(body.features) && body.features[0] === 0,
+        `features=${JSON.stringify(body.features)}`);
+    }
+  } catch (e) {
+    console.error(`Fatal: ${e.message}`);
+    console.error("--- server log ---\n" + serverLog);
+    failed++;
+  } finally {
+    child.kill();
+    stub.srv.close();
+  }
+
+  console.log("---");
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(`Fatal: ${e.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes four genuine bugs from the May batch and adds hermetic regression tests. Triage of the rest of the batch is in per-issue comments.

## Fixed here

### #21 — Eye advertised native classification but always fell back
`/api/constellation` and `/api/constellation.svg` reported `classifier: "native"` purely because `KANNAKA_BIN` existed on disk — but the kannaka CLI has no `classify` subcommand, so `classifyNative()` failed on every request and silently used the JS fallback. Added a memoized native-classifier **probe** (`nativeClassifierAvailable()`): both endpoints now report `native` only after the binary actually returns a glyph, otherwise `fallback`. Graceful today; reports `native` truthfully with no further change if a real `classify` subcommand ever ships.

### #24 — Constellation SVG always showed Memory active
The SVG hardcoded the Memory node into the active-dot set with no health check. Now gated on the same native probe. Status text distinguishes `NATIVE` / `UNVERIFIED` (binary present but probe failed) / `OFF`.

### #26 — Large-file upload crashed on a missing #info-text node
`handleFile()`'s >1 MB branch wrote progress to `getElementById('info-text')`, which the page never renders — a `null.textContent` throw before sampling. Routed to the existing `#canvasInfo` status line.

### #22 — NATS user:pass URLs misparsed as a token
`attention-bridge.js` parsed `nats://user:pass@host` into a single `auth_token`, so Eye couldn't authenticate to a username/password NATS server via `NATS_URL`. Now splits `user:pass` into separate CONNECT `user`/`pass` fields; bare `token@host` stays a token; explicit `NATS_USER`/`NATS_PASSWORD`/`NATS_TOKEN` env vars still take precedence. Connect log now shows `auth=user|token|none`.

## Not changed (already fixed on master, closing separately with evidence)
- **#25** (Save PNG const reassignment) — fixed in `e251a73`: `canvas`/`ctx` are `let` and `exportPNG()` saves/restores them.
- **#27** (0 BPM dropped) — fixed in `efacec7`: `/api/radio` uses `tempo_bpm != null`. Guard test added here anyway.
- **#23** (large-file sampling stops after first chunk) — fixed in `0997834`: `targetSampleChunks` stepping.

## Tests
`tests/bug_batch.mjs` (14 assertions) spawns the server with an unusable native classifier + a stub radio and drives each path: constellation classifier honesty (#21), SVG memory gating (#24), the `#canvasInfo` target (#26), `tempo_bpm:0` preservation (#27), and `parseNatsUrl` user:pass vs token (#22). Wired into CI after the SGA check. Existing 20 golden SGA vectors still pass; the JS 84-class taxonomy is untouched.

Closes #21
Closes #22
Closes #24
Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)