### PR TITLE
fix(attention-bridge): reconnect after a fatal NATS -ERR

### DIFF
--- a/attention-bridge.js
+++ b/attention-bridge.js
@@ -55,18 +55,44 @@ function parseNatsUrl(u) {
   };
 }
 
+/**
+ * NATS `-ERR` lines that leave the connection usable.
+ *
+ * Per the NATS protocol most `-ERR`s are fatal and the server closes the
+ * socket, but a permissions violation (or an invalid subject) is scoped to the
+ * offending operation — the connection stays up and is still good for other
+ * subjects. Tearing down on those would produce a pointless reconnect loop.
+ */
+const NON_FATAL_ERR = /permissions violation|invalid subject/i;
+
+/** @returns {boolean} true when this `-ERR` should cost us the connection. */
+function isFatalNatsError(line) {
+  return !NON_FATAL_ERR.test(line);
+}
+
 class AttentionBridge {
-  constructor() {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.url] Broker URL override. Defaults to NATS_URL.
+   *   Module-level env is read once at load, and this file is CommonJS — so a
+   *   test cannot re-read it by re-importing with a cache-busting query (the
+   *   CJS require cache keys on the resolved path and ignores the query).
+   *   An explicit override is the honest way to point an instance somewhere
+   *   else; production passes nothing and behaves exactly as before.
+   */
+  constructor(opts = {}) {
+    this._url = opts.url || NATS_URL;
     this._client = null;
     this._connected = false;
     this._buffer = "";
     this._reconnectTimer = null;
     this._published = 0;
     this._dropped = 0;
+    this._lastError = null;
   }
 
   connect() {
-    const parsed = parseNatsUrl(NATS_URL);
+    const parsed = parseNatsUrl(this._url);
     const { host, port } = parsed;
     // Auth precedence (#22): explicit env vars win, then credentials embedded
     // in NATS_URL. user/pass (if present) takes precedence over a token so a
@@ -87,6 +113,10 @@ class AttentionBridge {
       const lines = this._buffer.split("\r\n");
       this._buffer = lines.pop();
       for (const line of lines) {
+        // A fatal -ERR destroyed the socket earlier in this same chunk; the
+        // remaining lines belong to a connection that no longer exists, and
+        // writing a PONG to a destroyed socket just raises another error.
+        if (this._client !== sock) break;
         if (line.startsWith("INFO ")) {
           // Send CONNECT — minimal, no subscriptions needed (publish-only).
           const connect = { verbose: false, pedantic: false, lang: "node-raw", name: SOURCE_NAME, protocol: 1 };
@@ -105,6 +135,24 @@ class AttentionBridge {
         } else if (line === "PING") {
           sock.write("PONG\r\n");
         } else if (line.startsWith("-ERR")) {
+          this._lastError = line;
+          if (isFatalNatsError(line)) {
+            // Pre-fix this only logged. `_scheduleReconnect()` is reachable
+            // ONLY from the socket 'close' handler, so an -ERR the broker did
+            // not follow with a close — an auth rejection that leaves the TCP
+            // connection open — stranded the bridge forever: `_connected`
+            // never went true, every later glyph was dropped, and
+            // /api/attention/stats reported disconnected with nothing
+            // retrying. Destroy explicitly so 'close' fires and the existing
+            // 5s backoff takes over. (#47)
+            console.warn(`[attention-bridge] fatal NATS error, dropping connection to retry: ${line}`);
+            this._connected = false;
+            this._client = null;
+            try { sock.destroy(); } catch (_) { /* already gone */ }
+            break;
+          }
+          // Non-fatal: scoped to the offending operation, connection stays
+          // usable. Reconnecting here would loop without fixing anything.
           console.warn(`[attention-bridge] NATS error: ${line}`);
         }
       }
@@ -181,8 +229,17 @@ class AttentionBridge {
   }
 
   stats() {
-    return { connected: this._connected, hemisphere: HEMISPHERE, published: this._published, dropped: this._dropped };
+    return {
+      connected: this._connected,
+      hemisphere: HEMISPHERE,
+      published: this._published,
+      dropped: this._dropped,
+      // Last -ERR seen from the broker, so a bridge that is down for an
+      // auth/permissions reason says WHY rather than just "connected: false".
+      lastError: this._lastError,
+      reconnectPending: this._reconnectTimer != null,
+    };
   }
 }
 
-module.exports = { AttentionBridge, HEMISPHERE, SUBJECT, parseNatsUrl };
+module.exports = { AttentionBridge, HEMISPHERE, SUBJECT, parseNatsUrl, isFatalNatsError };

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -17,6 +17,10 @@
  *   #22  attention-bridge parses nats://user:pass@host into user/pass, and a
  *        bare nats://token@host into a token (pre-fix: user:pass sent as one
  *        auth_token).
+ *   #47  a fatal NATS -ERR drops the socket so the 5s reconnect fires
+ *        (pre-fix: -ERR only logged, and _scheduleReconnect() is reachable
+ *        only from 'close' — a broker that rejected auth without closing left
+ *        the bridge permanently dead).
  *
  * Usage: node tests/bug_batch.mjs   (exit 0 iff all pass)
  */
@@ -27,7 +31,7 @@ import { fileURLToPath } from "url";
 import net from "net";
 import http from "http";
 
-import { parseNatsUrl } from "../attention-bridge.js";
+import { AttentionBridge, parseNatsUrl, isFatalNatsError } from "../attention-bridge.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EYE_DIR = join(__dirname, "..");
@@ -126,6 +130,61 @@ async function main() {
 
     const plain = parseNatsUrl("nats://localhost:4222");
     check("#22 plain URL → no creds", plain.user === null && plain.token === null, `got user=${plain.user} token=${plain.token}`);
+  }
+
+  // ── #47: a fatal -ERR must drop the socket so a reconnect is scheduled ──
+  //
+  // Pre-fix, `-ERR` only logged. `_scheduleReconnect()` is reachable ONLY from
+  // the socket 'close' handler, so a broker that rejected auth WITHOUT closing
+  // the TCP connection stranded the bridge permanently: `_connected` never
+  // went true, every later glyph was dropped, and nothing ever retried.
+  {
+    check("#47 authorization violation is classified fatal",
+      isFatalNatsError("-ERR 'Authorization Violation'") === true);
+    check("#47 permissions violation is classified NON-fatal",
+      isFatalNatsError("-ERR 'Permissions Violation for Publish to KANNAKA.attention.eye'") === false,
+      "tearing down on a per-subject permissions error would just reconnect-loop");
+
+    // Fake broker that sends INFO then -ERR and then deliberately HOLDS the
+    // socket open — the exact condition the bug needs.
+    const held = [];
+    const broker = net.createServer((sock) => {
+      held.push(sock);
+      sock.write("INFO {\"server_id\":\"fake\"}\r\n");
+      sock.on("data", () => {});
+      setTimeout(() => { try { sock.write("-ERR 'Authorization Violation'\r\n"); } catch { /* gone */ } }, 30);
+      sock.on("error", () => {});
+    });
+    const bport = await new Promise((res) => broker.listen(0, "127.0.0.1", () => res(broker.address().port)));
+
+    // Point this instance at the fake broker explicitly. attention-bridge.js
+    // is CommonJS and reads NATS_URL once at module load, so setting the env
+    // here and re-importing with a cache-busting query does NOT work: the CJS
+    // require cache keys on the resolved path and ignores the query, handing
+    // back the already-evaluated module still aimed at localhost:4222.
+    const bridge = new AttentionBridge({ url: `nats://127.0.0.1:${bport}` });
+    bridge.connect();
+
+    await new Promise((r) => setTimeout(r, 400));
+
+    const st = bridge.stats();
+    check("#47 bridge is not left believing it is connected",
+      st.connected === false, `stats=${JSON.stringify(st)}`);
+    check("#47 a reconnect is actually scheduled after a fatal -ERR",
+      st.reconnectPending === true,
+      `nothing is retrying, so the link is permanently dead; stats=${JSON.stringify(st)}`);
+    check("#47 the reason is reported, not just 'disconnected'",
+      typeof st.lastError === "string" && st.lastError.includes("Authorization Violation"),
+      `got lastError=${JSON.stringify(st.lastError)}`);
+    check("#47 glyphs published while down are counted as dropped",
+      bridge.publishGlyph({ foldSequence: [1], amplitudes: [1] }, "text") === false &&
+      bridge.stats().dropped >= 1,
+      `stats=${JSON.stringify(bridge.stats())}`);
+
+    // Stop the 5s retry so the test process can exit promptly.
+    if (bridge._reconnectTimer) clearTimeout(bridge._reconnectTimer);
+    for (const s of held) { try { s.destroy(); } catch { /* ignore */ } }
+    broker.close();
   }
 
   const stub = await startStubRadio();


### PR DESCRIPTION
Closes #47.

## The bug

`-ERR` was handled by logging and nothing else:

```js
} else if (line.startsWith("-ERR")) {
  console.warn(`[attention-bridge] NATS error: ${line}`);
}
```

`_scheduleReconnect()` is reachable **only** from the socket `close` handler. So when a broker rejects the connection *without* closing the TCP socket — an authorization violation being the common case — the bridge is stranded permanently:

- `_connected` never becomes true (no PONG ever arrives)
- `publishGlyph` drops every subsequent glyph
- nothing schedules a retry
- `/api/attention/stats` reports `connected: false` forever, with no reason

The Eye→Attention link dies silently and stays dead until someone restarts the process.

## The fix

Fatal `-ERR`s now destroy the socket, so `close` fires and the **existing** 5s backoff takes over — no new retry machinery.

Permissions violations and invalid-subject errors are deliberately treated as **non-fatal**. Those are scoped to the offending operation and leave the connection usable for other subjects; tearing down on them would produce a reconnect loop that fixes nothing. That distinction is the one judgement call here, and it's covered by two unit assertions.

`stats()` gains `lastError` and `reconnectPending`, so a down bridge reports *why* rather than only `connected: false`. That also gives #46 something real to surface.

### One testability change

`AttentionBridge` takes an optional `{ url }` override. This is not gratuitous — I hit it directly: module-level env is read once at load, and `attention-bridge.js` is **CommonJS**, so re-importing with a cache-busting query (`import("../attention-bridge.js?err=" + Date.now())`) does *not* re-evaluate it. The CJS require cache keys on the resolved path and ignores the query string, so the test silently got the already-evaluated module still aimed at `localhost:4222` and the socket just took an ECONNREFUSED. Production passes nothing and behaves exactly as before.

## Verification

4 new cases in `tests/bug_batch.mjs` — already the home of the `#22` attention-bridge coverage, so **no CI change is needed**. They stand up a fake broker that sends `-ERR` and then deliberately **holds the socket open**, which is precisely the condition the bug requires.

| Check | Result |
|---|---|
| `node tests/bug_batch.mjs` | **20 passed, 0 failed** |
| `node tests/sga_consistency.mjs` | 20 passed, 0 failed |
| repo-wide `node --check` gate | clean |

**Revert-and-confirm-fail.** Reverting *only* the `-ERR` handling — keeping the helper, constructor and stats fields so the tests still load and the failures are behavioural rather than import errors:

```
PASS  #47 authorization violation is classified fatal
PASS  #47 permissions violation is classified NON-fatal
PASS  #47 bridge is not left believing it is connected          <- control
❌ FAIL  #47 a reconnect is actually scheduled after a fatal -ERR
         stats={"connected":false,...,"lastError":null,"reconnectPending":false}
❌ FAIL  #47 the reason is reported, not just 'disconnected'
PASS  #47 glyphs published while down are counted as dropped     <- control
Results: 18 passed, 2 failed
```

`reconnectPending: false` there is exactly the permanently-dead link this issue describes.

## Related

`#45` (bridge ignores `NATS_USER`/`NATS_PASSWORD`) is **already fixed** on `main` — see `attention-bridge.js:28-29`, `:76` and `:95`, landed under #22. I've closed it separately with evidence rather than bundling it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
