### PR TITLE
feat(constellation): surface attention-bridge state

### DIFF
--- a/server.js
+++ b/server.js
@@ -2177,7 +2177,8 @@ const server = http.createServer((req, res) => {
         eye: "#00e5ff",
         radio: "#f59e0b",
         memory: "#a78bfa",
-        dream: "#ec4899"
+        dream: "#ec4899",
+        attention: "#4ade80"
       };
 
       // Build active glyph dots. Eye is always active; radio lights only when
@@ -2185,10 +2186,15 @@ const server = http.createServer((req, res) => {
       // probe actually succeeds — previously Memory was hardcoded active with
       // no check at all, so the SVG implied kannaka-memory was wired up even
       // when Eye had verified nothing. (#24, #21)
+      // Attention lights only while the NATS bridge is actually connected —
+      // same honesty rule as Radio and Memory above. A dark Attention node is
+      // the visible signal that glyphs are being dropped. (#46)
+      const attentionOk = attentionBridge.stats().connected;
       const dots = [];
       dots.push({ idx: 0, source: "eye", label: "Eye" });
       if (radioState) dots.push({ idx: 3, source: "radio", label: "Radio" });
       if (nativeOk) dots.push({ idx: 6, source: "memory", label: "Memory" });
+      if (attentionOk) dots.push({ idx: 5, source: "attention", label: "Attention" });
 
       let svg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
@@ -2226,7 +2232,7 @@ const server = http.createServer((req, res) => {
       // Status text
       svg += `  <text x="200" y="380" text-anchor="middle" fill="#555" font-family="monospace" font-size="10">`;
       const memoryStatus = nativeOk ? "NATIVE" : (KANNAKA_BIN ? "UNVERIFIED" : "OFF");
-      svg += `eye:ON radio:${radioState ? "ON" : "OFF"} memory:${memoryStatus}`;
+      svg += `eye:ON radio:${radioState ? "ON" : "OFF"} memory:${memoryStatus} attention:${attentionOk ? "ON" : "OFF"}`;
       svg += `</text>\n`;
       svg += `</svg>`;
 
@@ -2288,6 +2294,10 @@ const server = http.createServer((req, res) => {
     <h2><span class="dot" id="dot-memory"></span> Memory</h2>
     <div class="meta" id="meta-memory">Checking...</div>
   </div>
+  <div class="card" id="card-attention">
+    <h2><span class="dot" id="dot-attention"></span> Attention</h2>
+    <div class="meta" id="meta-attention">Checking...</div>
+  </div>
 </div>
 
 <button class="refresh-btn" onclick="refresh()">Refresh</button>
@@ -2334,6 +2344,26 @@ function refresh() {
         document.getElementById("meta-memory").innerHTML =
           "Status: <span>native unavailable</span><br>" +
           "Classifier: <span>JS fallback</span>";
+      }
+
+      // Attention (Eye->NATS bridge). A dead bridge means every glyph is
+      // being dropped, which this dashboard used to render as fully healthy.
+      var att = data.attention || {};
+      if (att.connected) {
+        document.getElementById("dot-attention").className = "dot on";
+        document.getElementById("card-attention").className = "card online";
+        document.getElementById("meta-attention").innerHTML =
+          "Status: <span>connected</span><br>" +
+          "Hemisphere: <span>" + (att.hemisphere || "?") + "</span><br>" +
+          "Published: <span>" + (att.published || 0) + "</span>";
+      } else {
+        document.getElementById("dot-attention").className = "dot off";
+        document.getElementById("card-attention").className = "card offline";
+        document.getElementById("meta-attention").innerHTML =
+          "Status: <span>disconnected</span><br>" +
+          "Dropped: <span>" + (att.dropped || 0) + "</span><br>" +
+          (att.lastError ? "Error: <span>" + String(att.lastError).slice(0, 60) + "</span><br>" : "") +
+          "Retry: <span>" + (att.reconnectPending ? "scheduled" : "none") + "</span>";
       }
     })
     .catch(() => {
@@ -2388,6 +2418,20 @@ setInterval(refresh, 10000);
         currentAlbum: radioState.currentAlbum,
         track: currentTrack,
       } : { running: false };
+
+      // The Eye->Attention NATS link is part of the constellation, but this
+      // surface used to omit it entirely: a dead bridge left /api/constellation
+      // looking perfectly healthy while every glyph was being dropped. Report
+      // the live bridge state, including WHY it is down. (#46)
+      const a = attentionBridge.stats();
+      checks.attention = {
+        connected: a.connected,
+        hemisphere: a.hemisphere,
+        published: a.published,
+        dropped: a.dropped,
+        reconnectPending: a.reconnectPending,
+        lastError: a.lastError,
+      };
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(checks));

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -17,6 +17,9 @@
  *   #22  attention-bridge parses nats://user:pass@host into user/pass, and a
  *        bare nats://token@host into a token (pre-fix: user:pass sent as one
  *        auth_token).
+ *   #46  /api/constellation and constellation.svg report attention-bridge
+ *        state (pre-fix: a dead Eye->Attention link left every surface
+ *        looking healthy while glyphs were silently dropped).
  *   #47  a fatal NATS -ERR drops the socket so the 5s reconnect fires
  *        (pre-fix: -ERR only logged, and _scheduleReconnect() is reachable
  *        only from 'close' — a broker that rejected auth without closing left
@@ -247,6 +250,36 @@ async function main() {
       check("#27 /api/radio emits the 0 tempo byte first",
         Array.isArray(body.features) && body.features[0] === 0,
         `features=${JSON.stringify(body.features)}`);
+    }
+
+    // ── #46: constellation surfaces must include the attention bridge ──
+    //
+    // The server under test has no NATS broker, so its bridge is down and
+    // every glyph is being dropped. Pre-fix all three surfaces still looked
+    // healthy, because none of them mentioned the bridge at all.
+    {
+      const res = await request(port, "/api/constellation");
+      const body = JSON.parse(res.body);
+      check("#46 /api/constellation includes attention state",
+        body.attention !== undefined, `keys=${Object.keys(body).join(",")}`);
+      check("#46 attention reports disconnected with no broker",
+        body.attention && body.attention.connected === false,
+        `attention=${JSON.stringify(body.attention)}`);
+      check("#46 attention exposes the dropped counter",
+        body.attention && typeof body.attention.dropped === "number",
+        `attention=${JSON.stringify(body.attention)}`);
+      check("#46 attention exposes retry state so a dead link is diagnosable",
+        body.attention && "reconnectPending" in body.attention && "lastError" in body.attention,
+        `attention=${JSON.stringify(body.attention)}`);
+
+      const svg = await request(port, "/api/constellation.svg");
+      check("#46 SVG status line reports attention",
+        /attention:(ON|OFF)/.test(svg.body), `status line missing attention`);
+      check("#46 SVG reports attention OFF when the bridge is down",
+        /attention:OFF/.test(svg.body), `expected attention:OFF`);
+      check("#46 SVG does not light an Attention node while disconnected",
+        !svg.body.includes(">Attention<"),
+        "a dark bridge must not render as an active constellation node");
     }
   } catch (e) {
     console.error(`Fatal: ${e.message}`);


### PR DESCRIPTION
Closes #46. Follow-on to #49.

## The problem

The Eye→Attention NATS link was absent from **every** constellation surface. `/api/constellation` returned only `eye`, `classifier` and `radio`; the SVG had no Attention node; the `/constellation` dashboard had no card for it.

So when the bridge was down, all three surfaces looked healthy — while `publishGlyph` dropped every single glyph. The break was invisible at exactly the moment it mattered.

This is the same class of dishonesty already fixed for Radio (#17: a 500 error body lit the Radio node) and Memory (#21/#24: `KANNAKA_BIN` existing on disk was reported as `native`). Attention was simply never wired in.

## The change

**`/api/constellation`** gains an `attention` object:

```json
"attention": {
  "connected": false,
  "hemisphere": "left",
  "published": 0,
  "dropped": 47,
  "reconnectPending": true,
  "lastError": "-ERR 'Authorization Violation'"
}
```

`dropped` and `lastError` are the two that turn "something is wrong" into "here is what is wrong".

**`/api/constellation.svg`** lights an Attention node *only* while the bridge is genuinely connected, following the existing honesty rule rather than inventing a new one, and its status line gains `attention:ON|OFF` alongside `eye:` / `radio:` / `memory:`.

**The dashboard** gets an Attention card showing the dropped count, the broker's reason, and whether a retry is scheduled.

Together with #49 — which added `lastError` / `reconnectPending` to `AttentionBridge.stats()` and made a fatal `-ERR` actually reconnect — a dead bridge now both recovers on its own *and* explains itself.

## Verification

7 new cases in `tests/bug_batch.mjs`. Worth noting these are not artificial: the test server runs with **no NATS broker**, so its bridge is genuinely down and glyphs really are being dropped. That is precisely the state the surfaces used to render as healthy.

| Check | Result |
|---|---|
| `node tests/bug_batch.mjs` | **27 passed, 0 failed** |
| `node tests/sga_consistency.mjs` | 20 passed, 0 failed |
| repo-wide `node --check` gate | clean |

**Revert-and-confirm-fail.** Reverting only `server.js`:

```
❌ #46 /api/constellation includes attention state — keys=eye,classifier,radio
❌ #46 attention reports disconnected with no broker — attention=undefined
❌ #46 attention exposes the dropped counter — attention=undefined
❌ #46 attention exposes retry state so a dead link is diagnosable — attention=undefined
❌ #46 SVG status line reports attention — status line missing attention
❌ #46 SVG reports attention OFF when the bridge is down — expected attention:OFF
PASS  #46 SVG does not light an Attention node while disconnected   <- control
Results: 21 passed, 6 failed
```

`keys=eye,classifier,radio` in that first failure is the bug stated plainly.

The one control passes both ways by design — the pre-fix SVG has no Attention node to light, so "does not light it while disconnected" is vacuously true there and meaningful here.

## Note on the dashboard JS

`node --check server.js` only validates the enclosing template literal, not the client JS inside it. I extracted both inline `<script>` blocks and syntax-checked them separately (substituting the server-side `${...}` interpolations in the viewer block so it parses standalone). Both are valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
