### PR TITLE
fix(eye): report memory as an object; stop masking SGA class 0

### DIFF
--- a/server.js
+++ b/server.js
@@ -1481,7 +1481,9 @@ function updateStats(glyph) {
   document.getElementById('foldCount').textContent = glyph.foldSequence?.length || 0;
   document.getElementById('classesUsed').textContent = glyph.classesUsed || 0;
   document.getElementById('compressionRatio').textContent = glyph.compressionRatio ? glyph.compressionRatio.toFixed(1) + ':1' : '—';
-  document.getElementById('dominantClass').textContent = glyph.dominantClass || '—';
+  // ?? not || — class 0 is a real SGA class, and || rendered it as an em dash
+  // (i.e. "no data") for every glyph that legitimately folded to class 0. (#43)
+  document.getElementById('dominantClass').textContent = glyph.dominantClass ?? '—';
 }
 
 function updateMetadata(glyph) {
@@ -2406,6 +2408,18 @@ setInterval(refresh, 10000);
 
     Promise.all([radioCheck, nativeClassifierAvailable()]).then(([radioState, nativeOk]) => {
       checks.classifier = nativeOk ? "native" : "fallback";
+      // Memory had no object of its own: callers (and this repo's own
+      // dashboard) had to infer it by overloading the top-level `classifier`
+      // string. radio and attention are reported as objects, so memory being a
+      // bare inferred field made the surface inconsistent as well as thin.
+      // `classifier` is kept as-is for backwards compatibility. (#41)
+      checks.memory = {
+        available: nativeOk,
+        binaryConfigured: !!KANNAKA_BIN,
+        // Distinguishes "no binary configured" from "binary present but it
+        // cannot classify" — the two look identical through `classifier`.
+        status: nativeOk ? "native" : (KANNAKA_BIN ? "unverified" : "off"),
+      };
       // Prefer `current.title` (canonical now-playing) over a
       // playlist[currentTrackIdx] lookup which is null when /api/state
       // omits the playlist array. (#12)

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -17,6 +17,10 @@
  *   #22  attention-bridge parses nats://user:pass@host into user/pass, and a
  *        bare nats://token@host into a token (pre-fix: user:pass sent as one
  *        auth_token).
+ *   #41  /api/constellation exposes a `memory` object instead of forcing
+ *        callers to infer memory status from the `classifier` string.
+ *   #43  the viewer renders dominantClass 0 as "0", not an em dash (pre-fix:
+ *        `|| '—'` treated a legitimate class 0 as "no data").
  *   #46  /api/constellation and constellation.svg report attention-bridge
  *        state (pre-fix: a dead Eye->Attention link left every surface
  *        looking healthy while glyphs were silently dropped).
@@ -235,6 +239,16 @@ async function main() {
       check("#26 page routes large-file progress to #canvasInfo",
         html.includes("getElementById('canvasInfo').textContent"),
         "no canvasInfo progress write found");
+
+      // #43: class 0 is a real SGA class. `|| '—'` rendered it as "no data".
+      // Asserted against served page source, same approach as #26 — there is
+      // no browser harness in this repo.
+      check("#43 dominantClass uses ?? so class 0 is not masked",
+        html.includes("glyph.dominantClass ?? '—'"),
+        "expected nullish coalescing for dominantClass");
+      check("#43 dominantClass no longer uses || for its placeholder",
+        !html.includes("glyph.dominantClass || '—'"),
+        "|| masks a legitimate class 0 as an em dash");
       check("#26 page has no active #info-text null-deref call",
         !html.includes("getElementById('info-text').textContent"),
         "page still writes to a nonexistent #info-text element");
@@ -271,6 +285,19 @@ async function main() {
       check("#46 attention exposes retry state so a dead link is diagnosable",
         body.attention && "reconnectPending" in body.attention && "lastError" in body.attention,
         `attention=${JSON.stringify(body.attention)}`);
+
+      // ── #41: memory gets its own object, not an inferred `classifier` ──
+      check("#41 /api/constellation includes a memory object",
+        body.memory !== undefined && typeof body.memory === "object",
+        `keys=${Object.keys(body).join(",")}`);
+      check("#41 memory reports unverified when a binary is set but unusable",
+        body.memory && body.memory.status === "unverified" && body.memory.available === false,
+        `memory=${JSON.stringify(body.memory)}`);
+      check("#41 memory distinguishes 'configured' from 'usable'",
+        body.memory && body.memory.binaryConfigured === true,
+        `the test server sets KANNAKA_BIN to an unusable path; memory=${JSON.stringify(body.memory)}`);
+      check("#41 classifier is retained for backwards compatibility",
+        body.classifier === "fallback", `got classifier=${JSON.stringify(body.classifier)}`);
 
       const svg = await request(port, "/api/constellation.svg");
       check("#46 SVG status line reports attention",


### PR DESCRIPTION
Closes #41. Closes #43.

Two independent instances of the same shape of bug: **a real value reported as absent.**

## #41 — memory had no object, only an inferred string

`/api/constellation` returned `{eye, classifier, radio, attention}` with no `memory` field at all. Callers — including this repo's own dashboard, at `data.classifier === "native"` — had to infer memory status by overloading the top-level `classifier` string.

Two problems with that:

1. **It cannot express the interesting state.** `classifier: "fallback"` collapses "no binary configured" and "binary present but it cannot classify" into one value. Those need different operator responses, and the SVG status line already distinguishes them (`NATIVE` / `UNVERIFIED` / `OFF`) — the JSON just couldn't.
2. **It made the surface inconsistent.** `radio` is an object, and `attention` became one in #50. Memory being a bare inferred field was the odd one out.

Adds:

```json
"memory": { "available": false, "binaryConfigured": true, "status": "unverified" }
```

`classifier` is kept exactly as-is, so nothing that reads it today breaks — including the `#21` regression test and the dashboard.

> One correction to the issue as filed: it says the docs promise a `memory` field. I searched the README and `skills/` and could not find that promise anywhere, so I have not claimed a doc/code mismatch. The API-shape inconsistency above stands on its own.

## #43 — SGA class 0 rendered as "no data"

```js
document.getElementById('dominantClass').textContent = glyph.dominantClass || '—';
```

Class 0 is a **real** SGA class, not a sentinel. So every glyph that legitimately folded to class 0 displayed an em dash — the viewer's symbol for "nothing here". Changed to `??`, so only `null`/`undefined` produce the placeholder.

I checked for siblings: this was the only `|| '—'` in the file. `foldSequence?.length || 0` and `classesUsed || 0` are unaffected because `0 || 0` is still `0`.

## Verification

6 new cases in `tests/bug_batch.mjs`. The `#41` assertions are meaningful because the test server deliberately runs with `KANNAKA_BIN` set to an unusable path — the exact "configured but not usable" state the old `classifier` string could not express.

| Check | Result |
|---|---|
| `node tests/bug_batch.mjs` | **33 passed, 0 failed** |
| `node tests/sga_consistency.mjs` | 20 passed, 0 failed |
| repo-wide `node --check` gate | clean |

**Revert-and-confirm-fail** on `server.js` alone:

```
❌ #43 dominantClass uses ?? so class 0 is not masked
❌ #43 dominantClass no longer uses || for its placeholder
❌ #41 /api/constellation includes a memory object — keys=eye,classifier,radio,attention
❌ #41 memory reports unverified when a binary is set but unusable — memory=undefined
❌ #41 memory distinguishes 'configured' from 'usable' — memory=undefined
PASS  #41 classifier is retained for backwards compatibility   <- control
Results: 28 passed, 5 failed
```

The one survivor is the backwards-compatibility control, which must pass both ways or the change would be a breaking one.

`#43` is asserted against served page source, the same approach `#26` already uses — there is no browser harness in this repo. Inline `<script>` blocks were also extracted and syntax-checked separately, since `node --check server.js` validates only the enclosing template literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
