### PR TITLE
fix(eye): stop double-publishing the radio preset to attention

### DIFF
--- a/server.js
+++ b/server.js
@@ -1440,15 +1440,24 @@ async function processInput(data, type) {
       throw new Error(glyph.error);
     }
     
-    currentGlyph = glyph;
-    startAnimation();
-    
+    displayGlyph(glyph);
+
   } catch (error) {
     console.error('Error processing input:', error);
     document.getElementById('canvasInfo').textContent = 'Error: ' + error.message;
   } finally {
     showLoading(false);
   }
+}
+
+// Render an ALREADY-CLASSIFIED glyph. Split out of processInput so a caller
+// that already holds a glyph can display it without a second /api/process
+// round-trip — which would also publish it to the attention beam a second
+// time. renderGlyph drives updateCanvasInfo/updateStats/updateMetadata, so
+// this is the full UI update. (#38)
+function displayGlyph(glyph) {
+  currentGlyph = glyph;
+  startAnimation();
 }
 
 function showLoading(show) {
@@ -1797,7 +1806,18 @@ function initializePresets() {
       if (radio.error) throw new Error(radio.error);
       radioBtn.querySelector('.preset-desc').textContent =
         radio.track + ' (' + radio.featureCount + ' features)';
-      processInput(radio.features, 'bytes');
+      // /api/radio already classified these features AND published the glyph
+      // to the attention beam tagged "audio". Re-POSTing them to /api/process
+      // rendered the same listening event a second time and published it
+      // AGAIN, mislabelled as generic "bytes" — two gravity pulls per radio
+      // click. Display the glyph we were already handed. (#38)
+      if (radio.glyph) {
+        displayGlyph(radio.glyph);
+      } else {
+        // buildGlyphFromBytes failed server-side, so nothing was published;
+        // classifying here is the only publish and stays correct.
+        processInput(radio.features, 'bytes');
+      }
     } catch (e) {
       radioBtn.querySelector('.preset-desc').textContent = e.message;
     }

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -17,6 +17,10 @@
  *   #22  attention-bridge parses nats://user:pass@host into user/pass, and a
  *        bare nats://token@host into a token (pre-fix: user:pass sent as one
  *        auth_token).
+ *   #38  the Radio preset renders the glyph /api/radio already returned
+ *        instead of re-POSTing to /api/process (pre-fix: one radio click
+ *        published the same listening event to attention twice, the second
+ *        time mislabelled "bytes" instead of "audio").
  *   #41  /api/constellation exposes a `memory` object instead of forcing
  *        callers to infer memory status from the `classifier` string.
  *   #43  the viewer renders dominantClass 0 as "0", not an em dash (pre-fix:
@@ -239,6 +243,19 @@ async function main() {
       check("#26 page routes large-file progress to #canvasInfo",
         html.includes("getElementById('canvasInfo').textContent"),
         "no canvasInfo progress write found");
+
+      // #38: one radio click must produce ONE attention publish. /api/radio
+      // already classifies and publishes as "audio"; re-POSTing to
+      // /api/process published the same listening event again as "bytes".
+      check("#38 radio preset renders the glyph it was already given",
+        html.includes("displayGlyph(radio.glyph)"),
+        "radio preset should reuse the returned glyph, not re-classify");
+      check("#38 radio preset does not unconditionally re-POST to /api/process",
+        !/radio\.track \+ ' \(' \+ radio\.featureCount \+ ' features\)';\s*processInput\(/.test(html),
+        "an unconditional processInput() after /api/radio double-publishes");
+      check("#38 a null glyph still falls back to classifying locally",
+        html.includes("processInput(radio.features, 'bytes')"),
+        "the fallback must survive for when buildGlyphFromBytes returns null");
 
       // #43: class 0 is a real SGA class. `|| '—'` rendered it as "no data".
       // Asserted against served page source, same approach as #26 — there is


### PR DESCRIPTION
Closes #38.

## The bug

One click of the Radio preset produced **two** attention publishes for the same listening event.

1. `/api/radio` builds a glyph from the radio's audio features, publishes it as `attentionBridge.publishGlyph(glyph, "audio")`, and returns it in the response as `glyph`.
2. The browser **ignored that field** and immediately called `processInput(radio.features, 'bytes')`.
3. `/api/process` publishes again — tagged generic `"bytes"` instead of the richer `"audio"` source.

So the attention beam saw two gravity pulls per radio click, and the second, worse-provenance one is the one that landed last.

## The fix

The glyph was already sitting in the response; the UI just wasn't using it. Split `displayGlyph()` out of `processInput()` and render the returned glyph directly — no second round-trip, no second publish, and the `"audio"` tagging survives.

`renderGlyph` already drives `updateCanvasInfo` / `updateStats` / `updateMetadata`, so setting `currentGlyph` and animating is the complete UI update — the preset loses nothing by skipping `/api/process`.

**The fallback is kept deliberately.** When `radio.glyph` is null, `buildGlyphFromBytes` failed server-side and *nothing was published*, so classifying locally is then the only publish and remains correct. Removing that path would have traded a double-publish for a silently blank preset.

## Verification

3 new cases in `tests/bug_batch.mjs`, asserted against served page source — the same approach `#26` and `#43` use, since this repo has no browser harness.

| Check | Result |
|---|---|
| `node tests/bug_batch.mjs` | **36 passed, 0 failed** |
| `node tests/sga_consistency.mjs` | 20 passed, 0 failed |
| repo-wide `node --check` gate | clean |

**Revert-and-confirm-fail** on `server.js` alone:

```
❌ #38 radio preset renders the glyph it was already given
❌ #38 radio preset does not unconditionally re-POST to /api/process
PASS  #38 a null glyph still falls back to classifying locally   <- control
Results: 34 passed, 2 failed
```

The survivor is the fallback-path control, which must hold both ways or the fix would have deleted the degraded path instead of guarding it.

Inline `<script>` blocks were extracted and syntax-checked separately, since `node --check server.js` validates only the enclosing template literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
