### PR TITLE
fix(attention-bridge): honour the constellation-wide KANNAKA_NATS_URL

### DIFF
--- a/attention-bridge.js
+++ b/attention-bridge.js
@@ -20,7 +20,30 @@
 
 const net = require("net");
 
-const NATS_URL = process.env.NATS_URL || "nats://localhost:4222";
+const DEFAULT_NATS_URL = "nats://localhost:4222";
+
+/**
+ * Resolve the broker URL from the environment.
+ *
+ * KANNAKA_NATS_URL is the constellation-wide setting (kannaka-memory resolves
+ * it in ask.rs / identity.rs). The eye read only the generic NATS_URL, so on a
+ * box configured the constellation way it silently fell back to localhost:4222
+ * and published attention into a broker nobody was listening to. The specific
+ * name wins over the generic one — same rule as RADIO_PORT over PORT. (#35)
+ *
+ * Pure and exported so the precedence is testable without re-importing this
+ * module: it is CommonJS, so env read at load cannot be refreshed by an
+ * `import(...?bust=N)` — the CJS require cache ignores the query string.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {string}
+ */
+function resolveNatsUrl(env = process.env) {
+  const pick = (v) => (typeof v === "string" && v.trim() !== "" ? v.trim() : null);
+  return pick(env.KANNAKA_NATS_URL) || pick(env.NATS_URL) || DEFAULT_NATS_URL;
+}
+
+const NATS_URL = resolveNatsUrl();
 const NATS_TOKEN = process.env.NATS_TOKEN || null;
 // Oracle NATS uses user/password authz (the kannaka_internal account). The
 // KANNAKA.attention.eye subject is not in anon's publish allow-list, so the
@@ -242,4 +265,4 @@ class AttentionBridge {
   }
 }
 
-module.exports = { AttentionBridge, HEMISPHERE, SUBJECT, parseNatsUrl, isFatalNatsError };
+module.exports = { AttentionBridge, HEMISPHERE, SUBJECT, parseNatsUrl, isFatalNatsError, resolveNatsUrl, DEFAULT_NATS_URL };

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -17,6 +17,9 @@
  *   #22  attention-bridge parses nats://user:pass@host into user/pass, and a
  *        bare nats://token@host into a token (pre-fix: user:pass sent as one
  *        auth_token).
+ *   #35  the attention bridge honours the constellation-wide
+ *        KANNAKA_NATS_URL (pre-fix: only the generic NATS_URL was read, so a
+ *        correctly-configured box silently published to localhost:4222).
  *   #38  the Radio preset renders the glyph /api/radio already returned
  *        instead of re-POSTing to /api/process (pre-fix: one radio click
  *        published the same listening event to attention twice, the second
@@ -42,7 +45,7 @@ import { fileURLToPath } from "url";
 import net from "net";
 import http from "http";
 
-import { AttentionBridge, parseNatsUrl, isFatalNatsError } from "../attention-bridge.js";
+import { AttentionBridge, parseNatsUrl, isFatalNatsError, resolveNatsUrl, DEFAULT_NATS_URL } from "../attention-bridge.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EYE_DIR = join(__dirname, "..");
@@ -141,6 +144,27 @@ async function main() {
 
     const plain = parseNatsUrl("nats://localhost:4222");
     check("#22 plain URL → no creds", plain.user === null && plain.token === null, `got user=${plain.user} token=${plain.token}`);
+  }
+
+  // ── #35: KANNAKA_NATS_URL is the constellation-wide setting ──
+  //
+  // The bridge read only the generic NATS_URL, so a box configured the
+  // constellation way silently fell back to localhost:4222 and published
+  // attention into a broker nobody was listening to.
+  {
+    check("#35 KANNAKA_NATS_URL is honoured",
+      resolveNatsUrl({ KANNAKA_NATS_URL: "nats://broker:4222" }) === "nats://broker:4222");
+    check("#35 KANNAKA_NATS_URL outranks the generic NATS_URL",
+      resolveNatsUrl({ KANNAKA_NATS_URL: "nats://specific:4222", NATS_URL: "nats://generic:4222" }) === "nats://specific:4222",
+      "the constellation-specific name must win, same rule as RADIO_PORT over PORT");
+    check("#35 NATS_URL still works when KANNAKA_NATS_URL is unset",
+      resolveNatsUrl({ NATS_URL: "nats://legacy:4222" }) === "nats://legacy:4222",
+      "existing deployments must not break");
+    check("#35 falls back to localhost when neither is set",
+      resolveNatsUrl({}) === DEFAULT_NATS_URL);
+    check("#35 blank/whitespace values do not shadow the next source",
+      resolveNatsUrl({ KANNAKA_NATS_URL: "   ", NATS_URL: "nats://real:4222" }) === "nats://real:4222",
+      "an empty env var is not a configured broker");
   }
 
   // ── #47: a fatal -ERR must drop the socket so a reconnect is scheduled ──


### PR DESCRIPTION
Closes #35.

## The bug

`attention-bridge.js` read only the generic `NATS_URL`:

```js
const NATS_URL = process.env.NATS_URL || "nats://localhost:4222";
```

But `KANNAKA_NATS_URL` is the setting the rest of the constellation actually resolves — I confirmed it in kannaka-memory at `src/bin/handlers/ask.rs` (*"Honors --nats-url > KANNAKA_NATS_URL (folded into cfg at load) > ..."*) and `identity.rs`.

So on a box configured the constellation way, the eye silently fell back to `nats://localhost:4222` and published attention into a broker nobody was listening to. **Nothing errored** — the bridge reported `connected: true` against a local broker, or just sat retrying — the glyphs simply went nowhere. That is the worst kind of misconfiguration: it looks healthy.

## The fix

Precedence: **`KANNAKA_NATS_URL` → `NATS_URL` → `nats://localhost:4222`**.

The constellation-specific name beats the generic one. That's the same rule I applied to `RADIO_PORT` over `PORT` in kannaka-radio#163, and it's the right way round: a generic `NATS_URL` may well be set by unrelated tooling, whereas `KANNAKA_NATS_URL` is unambiguous intent. Existing `NATS_URL`-only deployments are unaffected.

### Why a pure function instead of an inline expression

Resolution is extracted into an exported `resolveNatsUrl(env)`. This module is **CommonJS**, so env read at load cannot be refreshed by re-importing with a cache-busting query — the CJS require cache keys on the resolved path and ignores the query string. An inlined expression would have been effectively untestable, and I know that concretely because it already bit me in #49: a test there silently exercised the cached module pointing at `localhost:4222` and two of its assertions passed for the wrong reason.

Blank and whitespace-only values are skipped, so `KANNAKA_NATS_URL=""` does not shadow a real `NATS_URL`.

## Verification

| Check | Result |
|---|---|
| `node tests/bug_batch.mjs` | **41 passed, 0 failed** |
| `node tests/sga_consistency.mjs` | 20 passed, 0 failed |
| repo-wide `node --check` gate | clean |

**Revert-and-confirm-fail**, reverting *only* the `KANNAKA_NATS_URL` term:

```
❌ #35 KANNAKA_NATS_URL is honoured
❌ #35 KANNAKA_NATS_URL outranks the generic NATS_URL
PASS  #35 NATS_URL still works when KANNAKA_NATS_URL is unset   <- control
PASS  #35 falls back to localhost when neither is set           <- control
PASS  #35 blank/whitespace values do not shadow the next source <- control
Results: 39 passed, 2 failed
```

The three survivors are backwards-compatibility and fallback controls, which must hold both ways or this would be a breaking change.

## Related

`#34` (bridge mis-encodes `nats://user:pass` as `auth_token`) is a **different** bug and is already fixed — closed separately today with evidence. Both were filed against the same file and both present as "the eye is not reaching the broker", which is probably why they coexisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
