### PR TITLE
fix(eye): keep levelDistribution on fallback radio glyphs

### DIFF
--- a/server.js
+++ b/server.js
@@ -152,6 +152,15 @@ async function buildGlyphFromBytes(bytes, sourceType) {
   const classCounts = {};
   for (const c of foldSequence.sequence) classCounts[c] = (classCounts[c] || 0) + 1;
   const dominantClass = Object.keys(classCounts).reduce((a, b) => (classCounts[a] > classCounts[b] ? a : b));
+  // This branch omitted levelDistribution entirely, even though the helper is
+  // documented as returning "the same shape /api/process emits" — so a
+  // fallback-classified radio glyph reached the viewer with no resonance-ring
+  // layer at all (renderResonanceRings bails on `!glyph.levelDistribution`).
+  // Computed exactly as the /api/process fallback does: over classifiedData,
+  // bucketed by the SGA `l` component. (#37)
+  const levelDistribution = new Array(8).fill(0);
+  for (const item of classifiedData) levelDistribution[item.components.l] += 1;
+  for (let i = 0; i < levelDistribution.length; i++) levelDistribution[i] /= count;
   return {
     foldSequence: foldSequence.sequence,
     amplitudes: foldSequence.amplitudes,
@@ -161,6 +170,7 @@ async function buildGlyphFromBytes(bytes, sourceType) {
     totalEnergy: foldSequence.amplitudes.reduce((s, a) => s + a, 0) / foldSequence.amplitudes.length,
     compressionRatio: classifiedData.length / foldSequence.sequence.length,
     dominantClass: parseInt(dominantClass),
+    levelDistribution,
     processedAt: new Date().toISOString(),
     classifier: "fallback",
     sourceType: sourceType || "bytes",

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -20,6 +20,9 @@
  *   #35  the attention bridge honours the constellation-wide
  *        KANNAKA_NATS_URL (pre-fix: only the generic NATS_URL was read, so a
  *        correctly-configured box silently published to localhost:4222).
+ *   #37  a fallback-classified /api/radio glyph still carries
+ *        levelDistribution (pre-fix: buildGlyphFromBytes omitted it, so the
+ *        viewer's resonance-ring layer silently did not render).
  *   #38  the Radio preset renders the glyph /api/radio already returned
  *        instead of re-POSTing to /api/process (pre-fix: one radio click
  *        published the same listening event to attention twice, the second
@@ -267,6 +270,38 @@ async function main() {
       check("#26 page routes large-file progress to #canvasInfo",
         html.includes("getElementById('canvasInfo').textContent"),
         "no canvasInfo progress write found");
+
+      // #37: a fallback-classified radio glyph must still carry the
+      // resonance-ring layer. The test server has no usable native classifier,
+      // so /api/radio necessarily takes the fallback branch — exactly the path
+      // that used to return a glyph with no levelDistribution at all.
+      {
+        const r = await request(port, "/api/radio");
+        if (r.status === 200) {
+          const rb = JSON.parse(r.body);
+          // Read defensively: when this regresses, levelDistribution is
+          // ABSENT, and a test that throws on the missing field would abort
+          // the whole suite instead of reporting a clean failure.
+          const ld = rb.glyph && Array.isArray(rb.glyph.levelDistribution)
+            ? rb.glyph.levelDistribution
+            : null;
+          check("#37 fallback radio glyph carries levelDistribution",
+            ld !== null,
+            `glyph keys=${JSON.stringify(rb.glyph && Object.keys(rb.glyph))}`);
+          check("#37 levelDistribution has the 8 buckets the viewer renders",
+            ld !== null && ld.length === 8,
+            `len=${ld === null ? "absent" : ld.length}`);
+          check("#37 levelDistribution is normalised to sum ~1",
+            ld !== null && Math.abs(ld.reduce((s, v) => s + v, 0) - 1) < 1e-9,
+            `sum=${ld === null ? "absent" : ld.reduce((s, v) => s + v, 0)}`);
+          check("#37 the fallback branch is genuinely the one under test",
+            rb.glyph && rb.glyph.classifier === "fallback",
+            `classifier=${rb.glyph && rb.glyph.classifier}`);
+        } else {
+          check("#37 /api/radio reachable for levelDistribution check", false,
+            `status=${r.status} body=${r.body.slice(0, 120)}`);
+        }
+      }
 
       // #38: one radio click must produce ONE attention publish. /api/radio
       // already classifies and publishes as "audio"; re-POSTing to


### PR DESCRIPTION
Closes #37 (the omission half — see the note at the bottom about the bucketing half, which I have deliberately not changed).

## The bug

`buildGlyphFromBytes()` is documented as returning *"the same shape `/api/process` emits"*. Its **fallback** branch omitted `levelDistribution` entirely.

Everywhere else has it:

| Path | `levelDistribution` |
|---|---|
| `/api/process` native | present, bucketed `cls % 8` |
| `/api/process` fallback | present, bucketed by `item.components.l` |
| `buildGlyphFromBytes` native | present, bucketed `cls % 8` |
| `buildGlyphFromBytes` fallback | **absent** |

So on any host without a working native classifier, a radio-derived glyph reached the viewer with no resonance-ring layer at all — `renderResonanceRings` bails on `!glyph.levelDistribution`, so the ring simply didn't draw. No error, just a quietly poorer render.

Computed exactly as the `/api/process` fallback does — over `classifiedData`, bucketed by the SGA `l` component — so the two fallback paths now agree instead of one being silently thinner.

## Verification

4 new cases in `tests/bug_batch.mjs`. These are well-targeted: the test server runs with an unusable `KANNAKA_BIN`, so `/api/radio` **necessarily** takes the fallback branch — the exact path that regressed. One assertion pins `classifier === "fallback"` so the test can't quietly start exercising the native branch and pass for the wrong reason.

| Check | Result |
|---|---|
| `node tests/bug_batch.mjs` | **45 passed, 0 failed** |
| `node tests/sga_consistency.mjs` | 20 passed, 0 failed |
| repo-wide `node --check` gate | clean |

**Revert-and-confirm-fail** on `server.js`:

```
❌ #37 fallback radio glyph carries levelDistribution — glyph keys=[...no levelDistribution...]
❌ #37 levelDistribution has the 8 buckets the viewer renders — len=absent
❌ #37 levelDistribution is normalised to sum ~1 — sum=absent
PASS  #37 the fallback branch is genuinely the one under test   <- control
Results: 42 passed, 3 failed
```

### A note on the test itself

My first version called `.reduce()` directly on the missing field. In the pre-fix state that **threw**, was caught by the suite's outer handler, and aborted the remaining ~20 checks — the revert run reported `22 passed, 3 failed` instead of `42 passed, 3 failed`. A gate that hides everything after it is worse than no gate, so the assertions now read `levelDistribution` defensively and fail cleanly.

## What I did NOT change, and why

The issue also observes that the **native** branch buckets by `cls % 8`, which is not the SGA `l` component. That is true, and it is a genuine inconsistency — but it is deeper than it looks, and I don't think it should be changed silently:

- the two branches bucket **different populations** — native over the post-fold `fold_sequence`, fallback over the pre-fold `classifiedData`
- and by **different keys** — `cls % 8` (range 0–7) vs `decodeClassIndex(cls).l` (range 0–6)

`sga_consistency.mjs` runs with the native classifier forced off, so the golden vectors only pin the fallback semantics. Aligning native to `decodeClassIndex(cls).l` would therefore move it *toward* the tested behaviour — but it would also change the rendered resonance ring for every native-classifier user, and it's a question about what `levelDistribution` is supposed to mean.

Worth deciding deliberately. Happy to implement whichever way you want it; I've left #37 open-able for that if you'd prefer to track it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
