### PR TITLE
fix(eye): stop announcing a native classifier that was never checked

### DIFF
--- a/server.js
+++ b/server.js
@@ -61,7 +61,15 @@ function radioRequest(subPath) {
   return { mod, target };
 }
 
-// Kannaka binary path — auto-detect or use env var
+// Kannaka binary path — explicit env var, else auto-detect.
+//
+// An explicitly-set KANNAKA_BIN deliberately wins even when the path does not
+// exist: silently substituting a different binary than the operator named is
+// worse than honouring the instruction and complaining about it. What was NOT
+// acceptable is doing that QUIETLY — the startup line below announced
+// "Native classifier: <path>" for a path that had never been checked, so a
+// typo'd env var read as a working native setup. (#48)
+const KANNAKA_BIN_EXPLICIT = !!process.env.KANNAKA_BIN;
 const KANNAKA_BIN = process.env.KANNAKA_BIN ||
   (() => {
     const candidates = [
@@ -75,7 +83,22 @@ const KANNAKA_BIN = process.env.KANNAKA_BIN ||
   })();
 
 if (KANNAKA_BIN) {
-  console.log(`[eye] Native classifier: ${KANNAKA_BIN}`);
+  const binExists = (() => { try { return fs.existsSync(KANNAKA_BIN); } catch { return false; } })();
+  if (binExists) {
+    console.log(`[eye] Native classifier: ${KANNAKA_BIN}`);
+  } else if (KANNAKA_BIN_EXPLICIT) {
+    console.warn(
+      `[eye] KANNAKA_BIN is set to "${KANNAKA_BIN}" but no file exists there — ` +
+      `every classification will use the JS fallback. Auto-detection is skipped ` +
+      `because KANNAKA_BIN was set explicitly; unset it to auto-detect instead.`,
+    );
+  } else {
+    // Auto-detected a path that has since disappeared (rebuild mid-run).
+    console.warn(
+      `[eye] auto-detected classifier "${KANNAKA_BIN}" is no longer present — ` +
+      `using the JS fallback. Restart to re-detect.`,
+    );
+  }
 } else {
   console.log(`[eye] Native classifier not found — using JS fallback`);
 }

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -17,6 +17,8 @@
  *   #22  attention-bridge parses nats://user:pass@host into user/pass, and a
  *        bare nats://token@host into a token (pre-fix: user:pass sent as one
  *        auth_token).
+ *   #48  startup does not announce "Native classifier: <path>" for a path it
+ *        never checked; an explicit-but-missing KANNAKA_BIN warns instead.
  *   #35  the attention bridge honours the constellation-wide
  *        KANNAKA_NATS_URL (pre-fix: only the generic NATS_URL was read, so a
  *        correctly-configured box silently published to localhost:4222).
@@ -251,6 +253,24 @@ async function main() {
       const body = JSON.parse(res.body);
       check("#21 /api/constellation classifier is 'fallback' when native unusable",
         body.classifier === "fallback", `got ${JSON.stringify(body.classifier)}`);
+    }
+
+    // ── #48: the startup line must not claim a classifier it never checked ──
+    //
+    // This server was spawned with KANNAKA_BIN pointed at FAKE_BIN, which does
+    // not exist — exactly the condition in the report. Pre-fix it printed
+    // "[eye] Native classifier: <path>" unconditionally, so a typo'd env var
+    // read as a working native setup in the logs.
+    {
+      check("#48 startup does not announce a native classifier that is absent",
+        !/\[eye\] Native classifier: /.test(serverLog),
+        `serverLog claimed a native classifier:\n${serverLog.slice(0, 300)}`);
+      check("#48 startup warns that KANNAKA_BIN points at nothing",
+        /KANNAKA_BIN is set to .* but no file exists there/.test(serverLog),
+        `expected an explicit warning; got:\n${serverLog.slice(0, 300)}`);
+      check("#48 the warning says why auto-detection did not rescue it",
+        /Auto-detection is skipped/.test(serverLog),
+        `the operator needs to know the explicit setting suppressed auto-detect`);
     }
 
     // ── #24: SVG does not light Memory without a verified probe ──


### PR DESCRIPTION
Closes #48.

## What was actually still broken

The report has three claims. Two are already fixed; one was not, and it's the one an operator hits first.

| Claim | Status |
|---|---|
| "still reports Eye as using the native classifier" (`/api/constellation`) | **already fixed** — `classifier` comes from a real probe (#21), and since #51 there's also `memory.status: "unverified"` for exactly this case |
| "skips the working auto-detected binary" | **true, and intended** — see below |
| startup log announces a native classifier | **was still broken** — fixed here |

Startup printed this whenever `KANNAKA_BIN` resolved to anything at all:

```js
if (KANNAKA_BIN) {
  console.log(`[eye] Native classifier: ${KANNAKA_BIN}`);
```

No `existsSync`, ever. So a typo'd env var read as a working native setup **in the logs** — the first place anyone looks when the classifier isn't behaving. The report's own repro shows it:

```
[eye] Native classifier: C:\nonexistent\kannaka.exe
```

Now the path is stat'd, and a missing one produces a warning that names the path, states that every classification will use the JS fallback, and explains that auto-detection was skipped because `KANNAKA_BIN` was set explicitly.

## Why explicit KANNAKA_BIN still wins

I kept the precedence. Silently substituting a *different* binary than the operator explicitly named is worse than honouring the instruction — if you pin `KANNAKA_BIN` and it's wrong, you want to be told, not quietly given something else. The defect was doing it **quietly**, not the precedence itself.

The warning names the escape hatch (unset it to auto-detect), so the auto-detected binary is one env change away rather than hidden.

## Verification

3 new cases in `tests/bug_batch.mjs`. These need no special setup: the suite already spawns its server with `KANNAKA_BIN` pointed at a nonexistent `FAKE_BIN`, so it **is** the reported condition — the assertions just read the captured startup log.

| Check | Result |
|---|---|
| `node tests/bug_batch.mjs` | **48 passed, 0 failed** |
| `node tests/sga_consistency.mjs` | 20 passed, 0 failed |
| repo-wide `node --check` gate | clean |

**Revert-and-confirm-fail** on `server.js` — all three go red:

```
❌ #48 startup does not announce a native classifier that is absent
❌ #48 startup warns that KANNAKA_BIN points at nothing
❌ #48 the warning says why auto-detection did not rescue it
Results: 45 passed, 3 failed
```

Also handled: a path that was auto-detected and has since disappeared (rebuild mid-run) gets its own, differently-worded warning, so the "unset KANNAKA_BIN" advice is never given to someone who never set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
