### PR TITLE
fix(radio bridge): Radio's idle payload is not a glyph (#56)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2100,6 +2100,37 @@ const server = http.createServer((req, res) => {
             return;
           }
           const perception = JSON.parse(data);
+
+          // Radio's IDLE payload is not perception. When nothing is playing,
+          // perception.js emits every field present but zeroed —
+          // mel_spectrogram: Array(128).fill(0), mfcc zeros, tempo 0,
+          // rms_energy 0, valence 0.5 — with an explicit
+          // `status: "no_perception"`.
+          //
+          // The #16 guard below only catches a payload with NO perception
+          // fields, so this one sailed past it: the zeros are real numbers,
+          // features.length > 0, and the eye rendered a confident glyph for
+          // "nothing is playing". A glyph that means silence is worse than no
+          // glyph, because it looks like a reading.
+          //
+          // Radio treats this marker the same way — server/index.js refuses to
+          // broadcast perception over WS when `status === 'no_perception'` —
+          // so this is honouring an existing contract, not inventing one. (#56)
+          if (perception && perception.status === "no_perception") {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            // 200, not 5xx: radio is healthy and answering, it simply has
+            // nothing to perceive. `idle`/`status` are the machine-readable
+            // signal; `error` is kept because it is the field the preset UI
+            // renders — without it the client falls through to classifying
+            // `radio.features`, which would be undefined here.
+            res.end(JSON.stringify({
+              idle: true,
+              status: "no_perception",
+              error: "Radio is idle — nothing playing, so there is no perception to render",
+            }));
+            return;
+          }
+
           // Convert perception features to bytes for classification
           const features = [];
           if (perception.mel_spectrogram) {

--- a/tests/bug_batch.mjs
+++ b/tests/bug_batch.mjs
@@ -120,17 +120,35 @@ async function waitReady(port, timeoutMs = 20000) {
 // tempo_bpm of 0 (the #27 edge case) and no other perception fields beyond
 // valence/energy.
 function startStubRadio() {
+  // `state.idle` flips the stub to Radio's real IDLE payload — a byte-for-byte
+  // copy of the initial value in kannaka-radio's server/perception.js. Every
+  // field is PRESENT and zeroed, which is precisely why the #16 "no perception
+  // fields" guard does not catch it. (#56)
+  const state = { idle: false };
+  const IDLE = {
+    mel_spectrogram: Array(128).fill(0),
+    mfcc: Array(13).fill(0),
+    tempo_bpm: 0,
+    spectral_centroid: 0,
+    rms_energy: 0,
+    pitch: 0,
+    valence: 0.5,
+    status: "no_perception",
+    track_info: null,
+  };
   return new Promise((resolve) => {
     const srv = http.createServer((req, res) => {
       if (req.url === "/api/perception") {
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ tempo_bpm: 0, valence: 0.5, rms_energy: 0.25 }));
+        res.end(JSON.stringify(
+          state.idle ? IDLE : { tempo_bpm: 0, valence: 0.5, rms_energy: 0.25 },
+        ));
       } else {
         res.writeHead(404);
         res.end("{}");
       }
     });
-    srv.listen(0, "127.0.0.1", () => resolve({ srv, port: srv.address().port }));
+    srv.listen(0, "127.0.0.1", () => resolve({ srv, port: srv.address().port, state }));
   });
 }
 
@@ -320,6 +338,42 @@ async function main() {
         } else {
           check("#37 /api/radio reachable for levelDistribution check", false,
             `status=${r.status} body=${r.body.slice(0, 120)}`);
+        }
+      }
+
+      // #56: Radio's IDLE payload must not become a glyph. When nothing is
+      // playing, perception.js emits every field present but ZEROED with an
+      // explicit status: "no_perception" — so the #16 "no perception fields"
+      // guard sails past it and the eye rendered a confident glyph for
+      // silence. Radio itself refuses to broadcast this payload over WS
+      // (server/index.js), so the marker is an existing contract.
+      {
+        stub.state.idle = true;
+        try {
+          const r = await request(port, "/api/radio");
+          const rb = (() => { try { return JSON.parse(r.body); } catch { return {}; } })();
+          check("#56 idle radio does not return a glyph",
+            !rb.glyph,
+            `glyph=${JSON.stringify(rb.glyph && Object.keys(rb.glyph))}`);
+          check("#56 idle radio is reported as idle, not as perception",
+            rb.idle === true && rb.status === "no_perception",
+            `idle=${rb.idle} status=${JSON.stringify(rb.status)}`);
+          // Radio is healthy — it simply has nothing to perceive — so this is
+          // not an upstream failure and must not be a 5xx.
+          check("#56 idle is not reported as an upstream failure",
+            r.status === 200,
+            `status=${r.status}`);
+          // The preset UI renders `error` and otherwise falls through to
+          // classifying `radio.features`; without a message it would try to
+          // classify undefined.
+          check("#56 idle carries a human-readable message for the preset UI",
+            typeof rb.error === "string" && rb.error.length > 0,
+            `error=${JSON.stringify(rb.error)}`);
+          check("#56 idle response carries no feature bytes",
+            !Array.isArray(rb.features) || rb.features.length === 0,
+            `featureCount=${Array.isArray(rb.features) ? rb.features.length : "absent"}`);
+        } finally {
+          stub.state.idle = false;
         }
       }
 


### PR DESCRIPTION
fix(radio bridge): Radio's idle payload is not a glyph (#56)

When nothing is playing, kannaka-radio's `perception.js` emits every
perception field PRESENT and zeroed — `mel_spectrogram: Array(128).fill(0)`,
zeroed mfcc, `tempo_bpm: 0`, `rms_energy: 0`, `valence: 0.5` — with an
explicit `status: "no_perception"`.

The existing #16 guard only refuses payloads with NO perception fields, so
this one sailed straight past it: the zeros are real numbers,
`features.length > 0`, and the eye synthesised a confident glyph for
silence. The gate makes it concrete — reverting produces a full 14-key
glyph from 144 zero bytes, `dominantClass` and `fanoSignature` included.

A glyph that means silence is worse than no glyph, because it looks like a
reading. It also publishes to the attention beam tagged "audio", so idle
Radio was contributing gravity as though it had perceived something.

`/api/radio` now honours the marker. This is an existing contract rather
than a new one: kannaka-radio's own `server/index.js` refuses to broadcast
perception over WS when `status === 'no_perception'` — the eye was the only
consumer not checking.

Response shape, deliberately:
  - 200, not 5xx. Radio is healthy and answering; it simply has nothing to
    perceive. That is not an upstream failure, and #16's 502 would conflate
    the two.
  - `idle: true` + `status` are the machine-readable signal.
  - `error` is retained because it is the field the preset UI renders. The
    client falls through to classifying `radio.features` when it is absent,
    which here would mean classifying `undefined`.

The test flips the stub Radio to a byte-for-byte copy of perception.js's
real initial value, so it exercises the actual payload rather than an
approximation of it.
