### PR TITLE
docs(classifier): the native probe's premise is out of date (#40)

### DIFF
--- a/server.js
+++ b/server.js
@@ -230,17 +230,25 @@ function classifyNative(inputBuffer) {
 /**
  * Probe whether the native classifier is actually usable (#21).
  *
- * KANNAKA_BIN existing on disk does NOT mean Eye can classify natively: the
- * current kannaka CLI has no `classify` subcommand, so classifyNative() fails
- * on every request and silently falls back to the JS classifier. Reporting
- * "native" from mere file presence made /api/constellation and the SVG lie
- * about whether memory-native classification is wired up.
+ * KANNAKA_BIN existing on disk does NOT mean Eye can classify natively.
+ * Reporting "native" from mere file presence made /api/constellation and the
+ * SVG lie about whether memory-native classification is wired up.
  *
  * Probe once with a tiny sample, memoize the result, and only let callers
- * claim "native" when the binary genuinely returns a classified glyph. If a
- * future kannaka ships a real classify subcommand this begins reporting native
- * truthfully with no further changes. Resolved once at first use, like
- * KANNAKA_BIN itself — a rebuild mid-run needs a restart to be picked up.
+ * claim "native" when the binary genuinely returns a classified glyph.
+ * Resolved once at first use, like KANNAKA_BIN itself — a rebuild mid-run
+ * needs a restart to be picked up.
+ *
+ * Status note (#40): when this was written the kannaka CLI had no `classify`
+ * subcommand at all, so the probe always failed. It does now — `classify` is
+ * behind the `glyph` feature, which is in kannaka's DEFAULT feature set, and a
+ * stock build answers stdin with JSON carrying `fold_sequence`. So the native
+ * path is live on a current binary and this probe reports it truthfully, which
+ * is exactly what it was built to do.
+ *
+ * The probe still matters, and is still the right shape: `glyph` can be
+ * switched off in a custom build, an older binary may predate the subcommand,
+ * and the CLI contract could change again. Presence on disk is not capability.
  */
 let _nativeProbe = null; // memoized Promise<boolean>
 function nativeClassifierAvailable() {


### PR DESCRIPTION
docs(classifier): the native probe's premise is out of date (#40)

The comment above `nativeClassifierAvailable()` asserted that "the
current kannaka CLI has no `classify` subcommand, so classifyNative()
fails on every request". That has not been true for a while, and the
stale claim is almost certainly what prompted #40 — it reads as a
statement about today rather than about when the probe was written.

Verified against real binaries rather than inferred:

  $ printf 'abc' | kannaka.exe classify
  {"amplitudes":[...],"fold_sequence":[...74 entries...],...}   exit 0

Both the debug and release builds answer. `classify` sits behind the
`glyph` feature, and `glyph` is in kannaka's DEFAULT feature set
(Cargo.toml: `default = ["hrm", "nats", "glyph", "nostr"]`), so a stock
build has it. The payload carries `fold_sequence`, which is exactly what
this probe tests for — so the native path is live on a current binary
and the probe already reports it truthfully, with no code change needed.
That is what the original fix (#21) was built to do.

No behaviour change here. The probe stays exactly as it is, and the note
now says why it still earns its place: `glyph` can be switched off in a
custom build, an older binary may predate the subcommand, and the CLI
contract could change again. Presence on disk is not capability — which
was the real point of #21 and is unaffected by the subcommand existing.

Existing suite: 53 passed, 0 failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
